### PR TITLE
[feat][CI] Update clang-format-action version

### DIFF
--- a/clang-format_check.yml
+++ b/clang-format_check.yml
@@ -6,5 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run clang-format style check for C programs.
-      uses: jidicula/clang-format-action@master
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v2.0.0


### PR DESCRIPTION
Related to jidicula/clang-format-action#18

**Why this change was necessary**
The `master` branch of `clang-format-action` is set to be deleted
on January 16. Additionally, the workflow version in that branch
does **not** support C++ files.

**What this change does**
Updates the CI style workflow to point to the earliest version of
`clang-format-action` supporting C++ files.

**Any side-effects?**
Style checks may fail now that C++ files are being checked.

**Additional context/notes/links**
 - https://github.com/jidicula/clang-format-action/releases/tag/v2.0.0